### PR TITLE
await Updates.reloadAsync

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ export default class ExpoCustomUpdater {
       await Updates.fetchUpdateAsync()
 
       this.log('doUpdateApp: Update fetched, reloading...')
-      Updates.reloadAsync()
+      await Updates.reloadAsync()
     } catch (e) {
       this.log(`doUpdateApp: ERROR: ${e.message}`)
     }


### PR DESCRIPTION
based on https://docs.expo.io/guides/configuring-ota-updates/#manual-updates and https://docs.expo.io/versions/latest/sdk/updates/#updatesreloadasync

might better to use `await Updates.reloadAsync()` instead of call `Updates.reloadAsync()` directly